### PR TITLE
update default config to enable threading if built for it

### DIFF
--- a/src/libretro/libretro_core_options.h
+++ b/src/libretro/libretro_core_options.h
@@ -182,7 +182,11 @@ struct retro_core_option_v2_definition option_defs_us[] = {
          { "enabled",  NULL },
          { NULL, NULL },
       },
+#ifndef EMULATORJS_THREADS
       "disabled"
+#else
+      "enabled"
+#endif
    },
 #endif
 #ifdef HAVE_OPENGL


### PR DESCRIPTION
Without this the webassembly stack spins up for threaded emulation but doesn't actually use the second thread. 